### PR TITLE
refactor: streamline main window initialization

### DIFF
--- a/src/gui/components/main_window_initializer.py
+++ b/src/gui/components/main_window_initializer.py
@@ -3,9 +3,6 @@
 MainWindow의 과도한 __init__ 메서드 로직을 분리하여 가독성과 유지보수성을 향상시킵니다.
 """
 
-import os
-from pathlib import Path
-
 from PyQt5.QtWidgets import QMainWindow
 
 from src.core.file_manager import FileManager
@@ -71,55 +68,6 @@ class MainWindowInitializer:
 
         # TMDB 검색 플래그
         self._tmdb_search_started = False
-
-    def initialize_all(self):
-        """모든 초기화를 순차적으로 실행"""
-        try:
-            print("🚀 메인 윈도우 초기화 시작...")
-
-            # 1. 기본 상태 초기화
-            self._init_basic_state()
-
-            # 2. 핵심 컴포넌트 초기화
-            self._init_core_components()
-
-            # 3. 데이터 관리자 초기화
-            self._init_data_managers()
-
-            # 4. 새로운 아키텍처 컴포넌트 초기화
-            self._init_new_architecture()
-
-            # 5. UI 상태 관리 및 마이그레이션 초기화
-            self._init_ui_state_management()
-
-            # 6. 접근성 및 국제화 관리자 초기화
-            self._init_accessibility_and_i18n()
-
-            print("✅ 메인 윈도우 초기화 완료!")
-
-        except Exception as e:
-            print(f"❌ 메인 윈도우 초기화 실패: {e}")
-            import traceback
-
-            traceback.print_exc()
-
-    def _init_basic_state(self):
-        """기본 상태 초기화"""
-        # 기본 설정
-        self.main_window.setWindowTitle("AnimeSorter")
-        self.main_window.setGeometry(100, 100, 1600, 900)
-
-        # 상태 초기화
-        self.main_window.scanning = False
-        self.main_window.progress = 0
-        self.main_window.source_files = []
-        self.main_window.source_directory = ""
-        self.main_window.destination_directory = None
-
-        # UI 컴포넌트 속성 초기화
-        self.main_window.status_progress = None
-
-        print("✅ 기본 상태 초기화 완료")
 
     def _init_core_components(self):
         """핵심 컴포넌트 초기화"""

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -12,7 +12,6 @@ from PyQt5.QtWidgets import QMainWindow, QMessageBox
 # New Architecture Components
 # UI Command Bridge
 # Local imports
-from src.core.settings_manager import SettingsManager
 from src.core.tmdb_client import TMDBClient
 from src.core.unified_config import unified_config_manager
 from src.core.unified_event_system import get_unified_event_bus
@@ -74,9 +73,6 @@ class MainWindow(QMainWindow):
         # UI 컴포넌트 속성 초기화
         self.status_progress = None  # 상태바 진행률 표시기
 
-        # 설정 관리자 초기화
-        self.settings_manager = SettingsManager()
-
         # 통합 이벤트 시스템 초기화
         self.unified_event_bus = get_unified_event_bus()
 
@@ -85,6 +81,9 @@ class MainWindow(QMainWindow):
         # 테마 디렉토리 경로 설정
         theme_dir = Path(__file__).parent.parent.parent / "data" / "theme"
         self.token_loader = TokenLoader(theme_dir)
+
+        # 모든 컴포넌트 초기화 (조율자를 통해)
+        self.coordinator.initialize_all_components()
 
         # New Controllers Initialization
         self._init_new_controllers()
@@ -102,9 +101,6 @@ class MainWindow(QMainWindow):
 
         # 통합 이벤트 시스템 연결
         self._connect_unified_event_system()
-
-        # 모든 컴포넌트 초기화 (조율자를 통해)
-        self.coordinator.initialize_all_components()
 
         # MainWindow 핸들러들 초기화 (Coordinator 초기화 완료 후 실행)
         print("🔧 MainWindow 핸들러들 초기화 시작...")


### PR DESCRIPTION
## Summary
- remove unused initialize_all and _init_basic_state from MainWindowInitializer
- drop unused imports
- rely on MainWindowCoordinator to configure core components and SettingsManager

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.base_table_model')*

------
https://chatgpt.com/codex/tasks/task_e_68bf741e2778833282ea3f94a6b668f8