### PR TITLE
Add libGL package to CI for headless Qt tests

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Qt environment for headless testing
       run: |
         sudo apt-get update
-        sudo apt-get install -y xvfb
+        sudo apt-get install -y xvfb libgl1-mesa-glx
         export QT_QPA_PLATFORM=offscreen
 
     - name: Run Ruff linting
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Qt environment
       run: |
         sudo apt-get update
-        sudo apt-get install -y xvfb
+        sudo apt-get install -y xvfb libgl1-mesa-glx
         export QT_QPA_PLATFORM=offscreen
 
     - name: Run smoke tests


### PR DESCRIPTION
## Summary
- install `libgl1-mesa-glx` alongside `xvfb` in headless Qt setup steps

## Testing
- `xvfb-run -a python -m pytest tests/`
- `xvfb-run -a python -m pytest tests/smoke/ -v` *(fails: file or directory not found: tests/smoke/)*
- `xvfb-run -a python -m pytest tests/test_base_components.py -v` *(fails: ModuleNotFoundError: No module named 'src.base_table_model')*


------
https://chatgpt.com/codex/tasks/task_e_68bf96e47c24833295553287c314a3ec