### PR TITLE
refactor: drop redundant else blocks

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -6,8 +6,11 @@
 from pathlib import Path
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QHeaderView  # Added for QHeaderView
-from PyQt5.QtWidgets import QMainWindow, QMessageBox
+from PyQt5.QtWidgets import (
+    QHeaderView,  # Added for QHeaderView
+    QMainWindow,
+    QMessageBox,
+)
 
 # New Architecture Components
 # UI Command Bridge
@@ -15,18 +18,23 @@ from PyQt5.QtWidgets import QMainWindow, QMessageBox
 from src.core.tmdb_client import TMDBClient
 from src.core.unified_config import unified_config_manager
 from src.core.unified_event_system import get_unified_event_bus
+
 # Phase 10.1: 접근성 관리 시스템
 # Phase 10.2: 국제화 관리 시스템
 # Phase 1: 메인 윈도우 분할 - 기능별 클래스 분리
 from src.gui.components.main_window_coordinator import MainWindowCoordinator
 from src.gui.components.message_log_controller import MessageLogController
+
 # UI Components
 from src.gui.components.settings_dialog import SettingsDialog
+
 # New Controllers for Refactoring
 from src.gui.components.theme_controller import ThemeController
+
 # Theme Engine Integration
 from src.gui.components.theme_manager import ThemeManager
 from src.gui.components.ui_state_controller import UIStateController
+
 # Phase 8: UI 상태 관리 및 마이그레이션
 # UI Components
 # Event Handler Manager
@@ -162,9 +170,8 @@ class MainWindow(QMainWindow):
         try:
             if self.unified_event_bus:
                 return self.unified_event_bus.publish(event)
-            else:
-                print("⚠️ 통합 이벤트 버스가 초기화되지 않았습니다")
-                return False
+            print("⚠️ 통합 이벤트 버스가 초기화되지 않았습니다")
+            return False
         except Exception as e:
             print(f"❌ 이벤트 발행 실패: {e}")
             return False
@@ -409,8 +416,9 @@ class MainWindow(QMainWindow):
         try:
             # MainWindowFileHandler 초기화 (필수)
             if hasattr(self, "file_processing_manager") and hasattr(self, "anime_data_manager"):
-                from src.gui.components.main_window.handlers.file_handler import \
-                    MainWindowFileHandler
+                from src.gui.components.main_window.handlers.file_handler import (
+                    MainWindowFileHandler,
+                )
 
                 self.file_handler = MainWindowFileHandler(
                     main_window=self,
@@ -425,23 +433,26 @@ class MainWindow(QMainWindow):
                 self.file_handler = None
 
             # MainWindowLayoutManager 초기화
-            from src.gui.components.main_window.handlers.layout_manager import \
-                MainWindowLayoutManager
+            from src.gui.components.main_window.handlers.layout_manager import (
+                MainWindowLayoutManager,
+            )
 
             self.layout_manager = MainWindowLayoutManager(main_window=self)
             print("✅ MainWindowLayoutManager 초기화 완료")
 
             # MainWindowMenuActionHandler 초기화
-            from src.gui.components.main_window.handlers.menu_action_handler import \
-                MainWindowMenuActionHandler
+            from src.gui.components.main_window.handlers.menu_action_handler import (
+                MainWindowMenuActionHandler,
+            )
 
             self.menu_action_handler = MainWindowMenuActionHandler(main_window=self)
             print("✅ MainWindowMenuActionHandler 초기화 완료")
 
             # MainWindowSessionManager 초기화
             if hasattr(self, "settings_manager"):
-                from src.gui.components.main_window.handlers.session_manager import \
-                    MainWindowSessionManager
+                from src.gui.components.main_window.handlers.session_manager import (
+                    MainWindowSessionManager,
+                )
 
                 self.session_manager = MainWindowSessionManager(
                     main_window=self, settings_manager=self.settings_manager
@@ -520,8 +531,7 @@ class MainWindow(QMainWindow):
             if str(src_dir) not in sys.path:
                 sys.path.insert(0, str(src_dir))
 
-            from src.gui.view_models.main_window_view_model_new import \
-                MainWindowViewModelNew
+            from src.gui.view_models.main_window_view_model_new import MainWindowViewModelNew
 
             print("📋 [MainWindow] ViewModel 초기화 시작...")
 
@@ -1333,8 +1343,7 @@ class MainWindow(QMainWindow):
         """테마 모니터링 위젯 표시"""
         try:
             if not self.theme_monitor_widget:
-                from src.gui.theme.theme_monitor_widget import \
-                    ThemeMonitorWidget
+                from src.gui.theme.theme_monitor_widget import ThemeMonitorWidget
 
                 self.theme_monitor_widget = ThemeMonitorWidget(self.theme_manager, self)
 
@@ -1380,16 +1389,14 @@ class MainWindow(QMainWindow):
             )
 
             # UI 상태 컨트롤러 설정
-            from src.gui.components.ui_state_controller import \
-                UIStateController
+            from src.gui.components.ui_state_controller import UIStateController
 
             self.ui_state_controller = UIStateController(
                 main_window=self, settings_manager=self.settings_manager
             )
 
             # 메시지 로그 컨트롤러 설정
-            from src.gui.components.message_log_controller import \
-                MessageLogController
+            from src.gui.components.message_log_controller import MessageLogController
 
             self.message_log_controller = MessageLogController(main_window=self)
 
@@ -1556,8 +1563,7 @@ class MainWindow(QMainWindow):
             if file_names:
                 if len(file_names) == 1:
                     return file_names[0]
-                else:
-                    return f"{file_names[0]} (+{len(file_names) - 1}개 파일)"
+                return f"{file_names[0]} (+{len(file_names) - 1}개 파일)"
             return "파일 정보 없음"
         except Exception as e:
             print(f"❌ 파일 정보 가져오기 실패: {e}")
@@ -1678,11 +1684,10 @@ class MainWindow(QMainWindow):
                 # 여전히 결과가 없으면 더 줄여서 재검색
                 self._try_progressive_search(group_id, shortened_title)
                 return
-            else:
-                # 여러 결과가 있으면 다이얼로그 표시
-                print(f"🔍 재검색 결과 {len(search_results)}개 - 다이얼로그 표시")
-                self._show_final_dialog(group_id, shortened_title, search_results)
-                return
+            # 여러 결과가 있으면 다이얼로그 표시
+            print(f"🔍 재검색 결과 {len(search_results)}개 - 다이얼로그 표시")
+            self._show_final_dialog(group_id, shortened_title, search_results)
+            return
 
         except Exception as e:
             print(f"❌ 단계적 검색 실패: {e}")
@@ -1772,12 +1777,11 @@ class MainWindow(QMainWindow):
         """에러 메시지를 표시합니다 (새 컨트롤러 사용)"""
         if self.message_log_controller:
             return self.message_log_controller.show_error_message(message, details, error_type)
-        else:
-            # 기존 방식으로 폴백
-            print(f"❌ {message}")
-            if details:
-                print(f"   상세: {details}")
-            return True
+        # 기존 방식으로 폴백
+        print(f"❌ {message}")
+        if details:
+            print(f"   상세: {details}")
+        return True
 
     def show_success_message(
         self, message: str, details: str = "", auto_clear: bool = True
@@ -1785,20 +1789,18 @@ class MainWindow(QMainWindow):
         """성공 메시지를 표시합니다 (새 컨트롤러 사용)"""
         if self.message_log_controller:
             return self.message_log_controller.show_success_message(message, details, auto_clear)
-        else:
-            # 기존 방식으로 폴백
-            print(f"✅ {message}")
-            if details:
-                print(f"   상세: {details}")
-            return True
+        # 기존 방식으로 폴백
+        print(f"✅ {message}")
+        if details:
+            print(f"   상세: {details}")
+        return True
 
     def show_info_message(self, message: str, details: str = "", auto_clear: bool = True) -> bool:
         """정보 메시지를 표시합니다 (새 컨트롤러 사용)"""
         if self.message_log_controller:
             return self.message_log_controller.show_info_message(message, details, auto_clear)
-        else:
-            # 기존 방식으로 폴백
-            print(f"ℹ️ {message}")
-            if details:
-                print(f"   상세: {details}")
-            return True
+        # 기존 방식으로 폴백
+        print(f"ℹ️ {message}")
+        if details:
+            print(f"   상세: {details}")
+        return True

--- a/src/gui/theme/engine/template_engine.py
+++ b/src/gui/theme/engine/template_engine.py
@@ -84,9 +84,8 @@ class TemplateEngine:
                 value = self._get_nested_value(variables, var_path)
                 if value is not None:
                     return str(value)
-                else:
-                    logger.warning(f"Variable not found: {var_path}")
-                    return match.group(0)  # Keep original placeholder
+                logger.warning(f"Variable not found: {var_path}")
+                return match.group(0)  # Keep original placeholder
             except Exception as e:
                 logger.error(f"Error resolving variable {var_path}: {e}")
                 return match.group(0)  # Keep original placeholder
@@ -113,9 +112,8 @@ class TemplateEngine:
                 value = self._find_css_variable_value(variables, var_name)
                 if value is not None:
                     return str(value)
-                else:
-                    logger.warning(f"CSS variable not found: {var_name}")
-                    return match.group(0)  # Keep original placeholder
+                logger.warning(f"CSS variable not found: {var_name}")
+                return match.group(0)  # Keep original placeholder
             except Exception as e:
                 logger.error(f"Error resolving CSS variable {var_name}: {e}")
                 return match.group(0)  # Keep original placeholder
@@ -167,22 +165,21 @@ class TemplateEngine:
             # Handle common CSS variable patterns
             if var_name == "primary-color":
                 return self._get_nested_value(variables, "colors.primary.500")
-            elif var_name == "primary-hover-color":
+            if var_name == "primary-hover-color":
                 return self._get_nested_value(variables, "colors.primary.600")
-            elif var_name == "text-color":
+            if var_name == "text-color":
                 return self._get_nested_value(variables, "colors.text.primary")
-            elif var_name == "text-muted-color":
+            if var_name == "text-muted-color":
                 return self._get_nested_value(variables, "colors.text.muted")
-            elif var_name == "background-color":
+            if var_name == "background-color":
                 return self._get_nested_value(variables, "colors.background.default")
-            elif var_name == "border-color":
+            if var_name == "border-color":
                 return self._get_nested_value(variables, "colors.border.default")
-            elif var_name == "focus-color":
+            if var_name == "focus-color":
                 return self._get_nested_value(variables, "colors.border.focus")
-            else:
-                # Try to find by converting kebab-case to dot notation
-                dot_path = var_name.replace("-", ".")
-                return self._get_nested_value(variables, dot_path)
+            # Try to find by converting kebab-case to dot notation
+            dot_path = var_name.replace("-", ".")
+            return self._get_nested_value(variables, dot_path)
 
         except Exception as e:
             logger.error(f"Error finding CSS variable {var_name}: {e}")

--- a/src/gui/view_models/settings/settings_view_model.py
+++ b/src/gui/view_models/settings/settings_view_model.py
@@ -8,11 +8,19 @@ from typing import Any
 
 from PyQt5.QtCore import QObject, pyqtProperty, pyqtSignal
 
-from src.app import (IUIUpdateService, SettingsChangedEvent,
-                     SettingsExportEvent, SettingsImportEvent,
-                     SettingsResetEvent, SettingsSavedEvent,
-                     StatusBarUpdateEvent, SuccessMessageEvent, TypedEventBus,
-                     get_event_bus, get_service)
+from src.app import (
+    IUIUpdateService,
+    SettingsChangedEvent,
+    SettingsExportEvent,
+    SettingsImportEvent,
+    SettingsResetEvent,
+    SettingsSavedEvent,
+    StatusBarUpdateEvent,
+    SuccessMessageEvent,
+    TypedEventBus,
+    get_event_bus,
+    get_service,
+)
 from src.core.unified_config import unified_config_manager
 
 from .settings_state import SettingsCapabilities, SettingsState
@@ -412,18 +420,17 @@ class SettingsViewModel(QObject):
                 config = self.settings_manager.config
                 if key == "destination_root":
                     return getattr(config.application, "destination_root", default)
-                elif key == "theme":
+                if key == "theme":
                     return getattr(config.user_preferences.theme_preferences, "theme", default)
-                elif key == "language":
+                if key == "language":
                     return getattr(config.user_preferences, "language", default)
-                elif key == "font_family":
+                if key == "font_family":
                     return getattr(config.user_preferences, "font_family", default)
-                elif key == "font_size":
+                if key == "font_size":
                     return getattr(config.user_preferences, "font_size", default)
-                elif key == "ui_style":
+                if key == "ui_style":
                     return getattr(config.user_preferences, "ui_style", default)
-                else:
-                    return default
+                return default
         except Exception as e:
             self.logger.error(f"설정 값 가져오기 실패: {e}")
             return default

--- a/tests/quality_metrics_collector.py
+++ b/tests/quality_metrics_collector.py
@@ -55,7 +55,7 @@ class QualityMetricsCollector:
         """기존 메트릭 히스토리 로드"""
         if self.metrics_file.exists():
             try:
-                with open(self.metrics_file, encoding="utf-8") as f:
+                with self.metrics_file.open(encoding="utf-8") as f:
                     data = json.load(f)
                     self.metrics_history = [
                         QualityMetric(**metric) for metric in data.get("metrics", [])
@@ -76,7 +76,7 @@ class QualityMetricsCollector:
                 "metrics": [asdict(metric) for metric in self.metrics_history],
             }
 
-            with open(self.metrics_file, "w", encoding="utf-8") as f:
+            with self.metrics_file.open("w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
 
             print(f"💾 메트릭 히스토리 저장됨: {self.metrics_file}")
@@ -323,17 +323,16 @@ class QualityMetricsCollector:
 
         if current_value < avg_previous * 0.9:  # 10% 이상 개선
             return "IMPROVING"
-        elif current_value > avg_previous * 1.1:  # 10% 이상 악화
+        if current_value > avg_previous * 1.1:  # 10% 이상 악화
             return "DECLINING"
-        else:
-            return "STABLE"
+        return "STABLE"
 
     def analyze_trends(self) -> list[QualityTrend]:
         """품질 트렌드 분석"""
         trends = []
 
         # 메트릭별로 그룹화
-        metric_groups = {}
+        metric_groups: dict[str, list[QualityMetric]] = {}
         for metric in self.metrics_history:
             if metric.metric_name not in metric_groups:
                 metric_groups[metric.metric_name] = []
@@ -417,7 +416,7 @@ class QualityMetricsCollector:
         report.append("")
 
         # 카테고리별 분석
-        categories = {}
+        categories: dict[str, list[QualityMetric]] = {}
         for metric in current_metrics:
             if metric.category not in categories:
                 categories[metric.category] = []


### PR DESCRIPTION
## Summary
- remove unnecessary `else` blocks following early returns across GUI, theme engine, view model, and tests
- replace `open()` calls with `Path.open()` and add type annotations in quality metrics collector

## Testing
- `SKIP=black,isort pre-commit run --files src/gui/main_window.py src/gui/theme/engine/template_engine.py src/gui/view_models/settings/settings_view_model.py tests/quality_metrics_collector.py` *(fails: mypy - incompatible types and missing annotations in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c096866f7c8332b700cb46faeceb87