### PR TITLE
Use Path objects for skipped files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,4 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
+        args: ["--profile", "black"]


### PR DESCRIPTION
## Summary
- store skipped file paths as `Path` objects rather than strings
- add missing type annotations in `file_organization_service`
- align isort with Black profile for consistent formatting

## Testing
- `pre-commit run --files src/app/services/file_organization_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0968b7b5c833295620ac31de311bd